### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           auto-update-python: true
           python-version: ${{ matrix.CONDA_PY }}
+          channels: conda-forge
       - name: "Install"
         run: |
           conda install -y -q -c conda-forge curl unzip matplotlib pytest nbval

--- a/devtools/prepare/transition_analysis_Abl.sh
+++ b/devtools/prepare/transition_analysis_Abl.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-conda install --yes --quiet pytables  # doesn't come with MDTraj?
+conda install --yes --quiet -c conda-forge pytables  # doesn't come with MDTraj?
 conda update --yes --quiet --all
 
 bash devtools/figshare_dl_extract.sh 4496795


### PR DESCRIPTION
It looks like the install process is currently causing tests to fail because matplotlib is being downgraded. This PR will get tests passing again.