### PR TITLE
Use mambaforge in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           auto-update-python: true
           python-version: ${{ matrix.CONDA_PY }}
+          miniforge-variant: Mambaforge
       - name: "Install"
         run: |
           conda install -y -q -c conda-forge curl unzip matplotlib pytest nbval


### PR DESCRIPTION
I'm trying to update this across several repos as a matter of performance. My fork was failing, but that's because I was missing an update to include the `conda-forge` channel, but I think that doing CI with `Mambaforge` is probably best practice now.