### PR TITLE
Fix bad mix of jupyer-core/nbval

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,14 +26,13 @@ jobs:
       - uses: actions/setup-python@v2
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          auto-update-python: true
           python-version: ${{ matrix.CONDA_PY }}
           miniforge-variant: Mambaforge
       - name: "Install"
         run: |
-          conda install -y -q -c conda-forge curl unzip matplotlib pytest nbval
           curl -OLk https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh
           source ./conda_ops_dev_install.sh
+          mamba install -y -q -c conda-forge curl unzip matplotlib pytest nbval
       - name: "Versions"
         run: conda list
       - name: "Tests"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/openpathsampling/ops_additional_examples/HEAD)
-![Test Suite](https://github.com/openpathsampling/ops_additional_examples/workflows/Test%20Suite/badge.svg)
+[![Test Suite](https://github.com/openpathsampling/ops_additional_examples/workflows/Test%20Suite/badge.svg)](https://github.com/openpathsampling/ops_additional_examples/actions/workflows/tests.yml)
 
 # Additional Examples for OpenPathSampling
 


### PR DESCRIPTION
Something has recently changed in the way `nbval` and `jupyter-core` are getting resolved in the installation process used here (which is common to many of my notebook tests; it's failing in all of them).

For whatever reason, it looks like it is pulling down a very old `jupyter-core` (4.5; we're currently on 4.11). This old version isn't compatible with current versions of `nbval`. Also, for reasons I haven't identified, we do *not* have the some problem with core OPS (there's a slight difference in how the installation happens, I guess.)

Hopefully I can fix it here, and will bring those changes over to some other OPS notebook repos that are failing now.